### PR TITLE
Initial OCR pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment configuration
+DATABASE_URL=postgresql://user:password@localhost:5432/pid

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+.venv/
+.env
+*.pyc
+*.pyo
+*.pyd
+.idea/
+*.png
+*.jpg
+*.jpeg
+*.csv
+*.xlsx

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# PID_digitalization
+# PID Digitalization
+
+This project provides tools to extract pipeline and equipment tag information from
+P\&ID diagrams (PDF or image files) using OCR. Recognized tags are stored in a
+PostgreSQL database for further processing and review.
+
+## Features
+
+- Image pre-processing (grayscale, threshold, denoise)
+- Multi-angle OCR (0\°, 90\°, 180\°, 270\°) with bounding box correction
+- Extraction of line numbers and equipment tags via regular expressions
+- Deduplication of OCR results across rotations
+- Results stored in PostgreSQL using settings from `.env`
+- Optional export to CSV or Excel
+- Modular structure prepared for future visualization or UI extensions
+
+## Setup
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Copy `.env.example` to `.env` and update the `DATABASE_URL` to point to your
+   PostgreSQL instance.
+
+3. Ensure Tesseract OCR and poppler utilities are installed on your system
+   (required by `pytesseract` and `pdf2image`).
+
+## Usage
+
+Process a folder of images or a single file:
+
+```bash
+python -m pidocr.main /path/to/folder --export results/output
+```
+
+OCR results will be inserted into the configured database. If `--export` is
+provided, CSV and Excel files will also be generated for each processed file.
+
+## Database Schema
+
+The application creates a table named `pid_entities` with the following columns:
+
+- `id` – serial primary key
+- `filename` – original file name
+- `page` – page number within the file
+- `tag_type` – `line_number` or `equipment_tag`
+- `tag_text` – recognized text
+- `left`, `top`, `width`, `height` – bounding box in pixels
+- `confidence` – OCR confidence value
+- `angle` – rotation angle used during OCR
+
+## Running Tests
+
+Unit tests are located in the `tests/` directory and can be executed with
+`pytest`:
+
+```bash
+pytest
+```
+
+## Project Goals
+
+The codebase is structured to allow future extensions such as deep learning
+models for improved OCR, interactive UIs for reviewing results, and web or
+desktop applications for visualization.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Pillow
+opencv-python-headless
+pytesseract
+pdf2image
+psycopg2-binary
+python-dotenv
+pandas

--- a/src/pidocr/__init__.py
+++ b/src/pidocr/__init__.py
@@ -1,0 +1,10 @@
+"""PID digitalization package."""
+
+__all__ = [
+    "preprocessing",
+    "ocr",
+    "extraction",
+    "deduplicate",
+    "database",
+    "exporter",
+]

--- a/src/pidocr/config.py
+++ b/src/pidocr/config.py
@@ -1,0 +1,16 @@
+"""Configuration utilities for pidocr."""
+
+from pathlib import Path
+from dotenv import load_dotenv
+import os
+
+load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / '.env')
+
+DATABASE_URL = os.getenv('DATABASE_URL', '')
+
+
+def get_database_url() -> str:
+    """Return the database connection URL from environment."""
+    if not DATABASE_URL:
+        raise ValueError('DATABASE_URL is not set in environment')
+    return DATABASE_URL

--- a/src/pidocr/database.py
+++ b/src/pidocr/database.py
@@ -1,0 +1,65 @@
+"""PostgreSQL interaction utilities."""
+from typing import Iterable
+import logging
+import psycopg2
+from psycopg2.extras import execute_values
+
+from .config import get_database_url
+from .extraction import ExtractedEntity
+
+logger = logging.getLogger(__name__)
+
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS pid_entities (
+    id SERIAL PRIMARY KEY,
+    filename TEXT,
+    page INTEGER,
+    tag_type TEXT,
+    tag_text TEXT,
+    left INTEGER,
+    top INTEGER,
+    width INTEGER,
+    height INTEGER,
+    confidence INTEGER,
+    angle INTEGER
+);
+"""
+
+INSERT_SQL = """
+INSERT INTO pid_entities
+(filename, page, tag_type, tag_text, left, top, width, height, confidence, angle)
+VALUES %s
+"""
+
+
+def init_db() -> None:
+    """Initialize database and create table if needed."""
+    conn = psycopg2.connect(get_database_url())
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute(CREATE_TABLE_SQL)
+    conn.close()
+
+
+def insert_entities(filename: str, page: int, entities: Iterable[ExtractedEntity]) -> None:
+    """Insert extracted entities into database."""
+    conn = psycopg2.connect(get_database_url())
+    records = [
+        (
+            filename,
+            page,
+            ent.entity_type,
+            ent.text,
+            ent.left,
+            ent.top,
+            ent.width,
+            ent.height,
+            ent.conf,
+            ent.angle,
+        )
+        for ent in entities
+    ]
+    with conn:
+        with conn.cursor() as cur:
+            execute_values(cur, INSERT_SQL, records)
+    conn.close()

--- a/src/pidocr/deduplicate.py
+++ b/src/pidocr/deduplicate.py
@@ -1,0 +1,30 @@
+"""Deduplication utilities for OCR results."""
+from typing import List
+from .ocr import OCRResult
+
+
+def deduplicate_results(results: List[OCRResult], iou_threshold: float = 0.5) -> List[OCRResult]:
+    """Remove near-duplicate OCR results based on overlap and text match."""
+    deduped: List[OCRResult] = []
+    for res in results:
+        duplicate = False
+        for other in deduped:
+            if res.text == other.text and _iou(res, other) > iou_threshold:
+                duplicate = True
+                break
+        if not duplicate:
+            deduped.append(res)
+    return deduped
+
+
+def _iou(a: OCRResult, b: OCRResult) -> float:
+    """Compute intersection-over-union of two boxes."""
+    x1 = max(a.left, b.left)
+    y1 = max(a.top, b.top)
+    x2 = min(a.left + a.width, b.left + b.width)
+    y2 = min(a.top + a.height, b.top + b.height)
+    inter_area = max(0, x2 - x1) * max(0, y2 - y1)
+    area_a = a.width * a.height
+    area_b = b.width * b.height
+    union = area_a + area_b - inter_area
+    return inter_area / union if union else 0.0

--- a/src/pidocr/exporter.py
+++ b/src/pidocr/exporter.py
@@ -1,0 +1,30 @@
+"""Export utilities for PID OCR results."""
+from typing import Iterable
+import pandas as pd
+from .extraction import ExtractedEntity
+
+
+def _to_records(filename: str, page: int, entities: Iterable[ExtractedEntity]):
+    for ent in entities:
+        yield {
+            "filename": filename,
+            "page": page,
+            "tag_type": ent.entity_type,
+            "tag_text": ent.text,
+            "left": ent.left,
+            "top": ent.top,
+            "width": ent.width,
+            "height": ent.height,
+            "confidence": ent.conf,
+            "angle": ent.angle,
+        }
+
+
+def export_to_csv(filename: str, page: int, entities: Iterable[ExtractedEntity], output_path: str) -> None:
+    """Export entities to CSV file."""
+    pd.DataFrame(list(_to_records(filename, page, entities))).to_csv(output_path, index=False)
+
+
+def export_to_excel(filename: str, page: int, entities: Iterable[ExtractedEntity], output_path: str) -> None:
+    """Export entities to Excel file."""
+    pd.DataFrame(list(_to_records(filename, page, entities))).to_excel(output_path, index=False)

--- a/src/pidocr/extraction.py
+++ b/src/pidocr/extraction.py
@@ -1,0 +1,38 @@
+"""Entity extraction utilities."""
+from dataclasses import dataclass
+import re
+from typing import Iterable, List
+from .ocr import OCRResult
+
+LINE_PATTERN = re.compile(r"\b[A-Z]{1,2}\d{2,}\b")
+EQUIPMENT_PATTERN = re.compile(r"\b[A-Z]{1,3}-\d{3,}\b")
+
+
+@dataclass
+class ExtractedEntity(OCRResult):
+    """OCR result with classified entity."""
+    entity_type: str
+
+
+def extract_entities(results: Iterable[OCRResult]) -> List[ExtractedEntity]:
+    """Extract equipment tags and line numbers from OCR results."""
+    entities: List[ExtractedEntity] = []
+    for res in results:
+        if LINE_PATTERN.search(res.text):
+            etype = "line_number"
+        elif EQUIPMENT_PATTERN.search(res.text):
+            etype = "equipment_tag"
+        else:
+            continue
+        entity = ExtractedEntity(
+            text=res.text,
+            left=res.left,
+            top=res.top,
+            width=res.width,
+            height=res.height,
+            conf=res.conf,
+            angle=res.angle,
+            entity_type=etype,
+        )
+        entities.append(entity)
+    return entities

--- a/src/pidocr/main.py
+++ b/src/pidocr/main.py
@@ -1,0 +1,55 @@
+"""Command line interface for PID OCR processing."""
+import argparse
+import logging
+from pathlib import Path
+from pdf2image import convert_from_path
+from PIL import Image
+
+from .preprocessing import load_image, preprocess_image
+from .ocr import ocr_image
+from .extraction import extract_entities
+from .deduplicate import deduplicate_results
+from .database import init_db, insert_entities
+from .exporter import export_to_csv, export_to_excel
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def process_file(path: Path, page: int = 1, export: Path | None = None) -> None:
+    """Process a single image or PDF file."""
+    if path.suffix.lower() == ".pdf":
+        images = convert_from_path(path)
+    else:
+        images = [load_image(path)]
+
+    for page_num, img in enumerate(images, start=page):
+        processed = preprocess_image(img)
+        ocr_results = ocr_image(processed)
+        deduped = deduplicate_results(ocr_results)
+        entities = extract_entities(deduped)
+        insert_entities(path.name, page_num, entities)
+        if export:
+            export_to_csv(path.name, page_num, entities, str(export.with_suffix(".csv")))
+            export_to_excel(path.name, page_num, entities, str(export.with_suffix(".xlsx")))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Process PID images for OCR")
+    parser.add_argument("input", type=Path, help="Input file or directory")
+    parser.add_argument("--export", type=Path, help="Optional path prefix for CSV/Excel export")
+    args = parser.parse_args()
+
+    init_db()
+
+    if args.input.is_dir():
+        for file in args.input.iterdir():
+            if file.suffix.lower() in {".pdf", ".png", ".jpg", ".jpeg", ".tiff"}:
+                logger.info("Processing %s", file)
+                process_file(file, export=args.export)
+    else:
+        process_file(args.input, export=args.export)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pidocr/ocr.py
+++ b/src/pidocr/ocr.py
@@ -1,0 +1,64 @@
+"""OCR utilities with multi-angle support."""
+from dataclasses import dataclass
+from typing import List
+from PIL import Image
+import pytesseract
+
+
+@dataclass
+class OCRResult:
+    """Data for a single OCR result."""
+    text: str
+    left: int
+    top: int
+    width: int
+    height: int
+    conf: int
+    angle: int
+
+
+def _rotate_image(image: Image.Image, angle: int) -> Image.Image:
+    """Rotate image by angle degrees."""
+    return image.rotate(angle, expand=True)
+
+
+def _transform_bbox(bbox: tuple, angle: int, orig_size: tuple) -> tuple:
+    """Transform bounding box from rotated image to original coordinates."""
+    x, y, w, h = bbox
+    if angle == 0:
+        return bbox
+    img_w, img_h = orig_size
+    if angle == 90:
+        return (img_h - y - h, x, h, w)
+    if angle == 180:
+        return (img_w - x - w, img_h - y - h, w, h)
+    if angle == 270:
+        return (y, img_w - x - w, h, w)
+    return bbox
+
+
+def ocr_image(image: Image.Image, angles: List[int] | None = None) -> List[OCRResult]:
+    """Run OCR on image for multiple angles."""
+    if angles is None:
+        angles = [0, 90, 180, 270]
+    results: List[OCRResult] = []
+    for angle in angles:
+        rotated = _rotate_image(image, angle)
+        data = pytesseract.image_to_data(rotated, output_type=pytesseract.Output.DICT)
+        n_boxes = len(data['text'])
+        for i in range(n_boxes):
+            text = data['text'][i].strip()
+            if text:
+                bbox = (data['left'][i], data['top'][i], data['width'][i], data['height'][i])
+                bbox = _transform_bbox(bbox, angle, image.size)
+                result = OCRResult(
+                    text=text,
+                    left=bbox[0],
+                    top=bbox[1],
+                    width=bbox[2],
+                    height=bbox[3],
+                    conf=int(float(data['conf'][i])),
+                    angle=angle,
+                )
+                results.append(result)
+    return results

--- a/src/pidocr/preprocessing.py
+++ b/src/pidocr/preprocessing.py
@@ -1,0 +1,21 @@
+"""Image loading and preprocessing utilities."""
+from pathlib import Path
+from typing import Union
+from PIL import Image, ImageFilter
+import cv2
+import numpy as np
+
+
+def load_image(path: Union[str, Path]) -> Image.Image:
+    """Load an image from disk."""
+    return Image.open(path)
+
+
+def preprocess_image(image: Image.Image) -> Image.Image:
+    """Convert image to grayscale and apply thresholding and denoising."""
+    gray = image.convert("L")
+    img_array = np.array(gray)
+    _, thresh = cv2.threshold(img_array, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    denoised = cv2.medianBlur(thresh, 3)
+    result = Image.fromarray(denoised).filter(ImageFilter.SHARPEN)
+    return result

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,15 @@
+from unittest import mock
+from pidocr.database import insert_entities
+from pidocr.extraction import ExtractedEntity
+
+
+def test_insert_entities_calls_db():
+    entity = ExtractedEntity(text="A1", left=0, top=0, width=1, height=1, conf=90, angle=0, entity_type="line_number")
+    with mock.patch("pidocr.database.psycopg2.connect") as m_connect, \
+         mock.patch("pidocr.database.get_database_url", return_value="postgresql://test"), \
+         mock.patch("pidocr.database.execute_values") as m_exec:
+        mock_conn = m_connect.return_value
+        insert_entities("file.png", 1, [entity])
+        assert m_connect.called
+        m_exec.assert_called_once()
+        mock_conn.cursor.assert_called()

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -1,0 +1,9 @@
+from pidocr.ocr import OCRResult
+from pidocr.deduplicate import deduplicate_results
+
+
+def test_deduplicate_results():
+    r1 = OCRResult(text="A1", left=10, top=10, width=50, height=20, conf=90, angle=0)
+    r2 = OCRResult(text="A1", left=12, top=12, width=50, height=20, conf=88, angle=90)
+    deduped = deduplicate_results([r1, r2])
+    assert len(deduped) == 1

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,18 @@
+from PIL import Image, ImageDraw
+import pytest
+import pytesseract
+
+from pidocr.ocr import ocr_image
+
+
+def test_ocr_image(tmp_path):
+    try:
+        pytesseract.get_tesseract_version()
+    except pytesseract.TesseractNotFoundError:
+        pytest.skip("tesseract not installed")
+    img = Image.new("RGB", (200, 100), color="white")
+    draw = ImageDraw.Draw(img)
+    draw.text((10, 40), "A1-001", fill="black")
+    results = ocr_image(img, angles=[0])
+    texts = [r.text for r in results]
+    assert any("A1-001" in t for t in texts)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,10 @@
+from PIL import Image
+from pidocr.preprocessing import preprocess_image
+
+def test_preprocess_image(tmp_path):
+    img_path = tmp_path / "test.png"
+    Image.new("RGB", (100, 100), color="white").save(img_path)
+    img = Image.open(img_path)
+    processed = preprocess_image(img)
+    assert processed.mode == "L"
+    assert processed.size == img.size


### PR DESCRIPTION
## Summary
- add OCR pipeline modules for PID diagrams
- implement preprocessing, multi-angle OCR, entity extraction, and dedupe
- store results in PostgreSQL and optionally export to CSV/Excel
- provide CLI entry point and environment config
- set up unit tests and documentation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499aa58d94832287b733c038b79aa7